### PR TITLE
Bugfix: RemoveLoginAsync() method in UserStore was throwing

### DIFF
--- a/src/AspNet.Identity3.MongoDB/UserStore.cs
+++ b/src/AspNet.Identity3.MongoDB/UserStore.cs
@@ -197,7 +197,7 @@ namespace AspNet.Identity3.MongoDB
                 .Where(l => l.LoginProvider == loginProvider &&
                             l.ProviderKey == providerKey);
 
-            foreach (var login in loginsToRemove)
+            foreach (var login in loginsToRemove.ToArray())
             {
                 user.Logins.Remove(login);
             }

--- a/test/Tests/MongoIdentityUserTests.cs
+++ b/test/Tests/MongoIdentityUserTests.cs
@@ -25,8 +25,7 @@ namespace Tests
         {
             var user = new IdentityUser();
 
-            ObjectId userObjectId;
-            ObjectId.TryParse(user.Id, out userObjectId);
+            ObjectId userObjectId = user.Id;
 
             Assert.NotNull(userObjectId);
             Assert.NotEqual(userObjectId, ObjectId.Empty);


### PR DESCRIPTION
The RemoveLoginAsync() method threw because it removed stuff from the list of logins while it was `foreach`-ing over it. 

I also noticed a test wasn't updated after the latest change with the userid.
